### PR TITLE
docs: fix swagger link

### DIFF
--- a/docs/bam/index.md
+++ b/docs/bam/index.md
@@ -11,4 +11,4 @@ The BUNN Asset Management API provides customer access to remote configuration a
 
 ## Technical Documentation
 
-Please view our [Swagger](https://api.bunn.com/bunn-asset-management/swagger-ui/) API Documentation.
+Please view our [Swagger](https://api.bunn.com/bunn-asset-management/swagger-ui/index.html) API Documentation.


### PR DESCRIPTION
Update the link for BAM's swagger page. It changed as part of the Spring boot update.